### PR TITLE
Removed default environment name

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ load_conda(
 )
 
 conda_create(
-    name = "py3_env",  # name of the environment, default is my_env
+    name = "py3_env",  # name of the environment
     environment = "@//:py3_environment.yml",  # label pointing to environment configuration file
     use_mamba = True,  # Whether to use mamba to create the conda environment. If this is True, install_mamba must also be True	False
     clean = False,  # True if conda cache should be cleaned (less space taken, but slower subsequent builds), default is False
@@ -83,7 +83,7 @@ conda_create(
 )
 
 conda_create(
-    name = "py2_env",  # name of the environment, default is my_env
+    name = "py2_env",  # name of the environment
     environment = "@//:py2_environment.yml",  # label pointing to environment configuration file
 )
 

--- a/defs.bzl
+++ b/defs.bzl
@@ -6,7 +6,6 @@ load(":toolchain.bzl", "toolchain_rule")
 CONDA_REPO_NAME = "conda"
 CONDA_DIR = "conda"
 DEFAULT_CONDA_VERSION = "4.10.3"
-DEFAULT_ENV_NAME = "my_env"
 DEFAULT_TOOLCHAIN_REPO_NAME = "conda_tools"
 DEFAULT_TOOLCHAIN_NAME = "python_toolchain"
 DEFAULT_MAMBA_VERSION = "0.17.0"
@@ -23,7 +22,7 @@ def load_conda(conda_version = DEFAULT_CONDA_VERSION, mamba_version = DEFAULT_MA
     )
 
 # create conda environment
-def conda_create(name = DEFAULT_ENV_NAME, **kwargs):
+def conda_create(name, **kwargs):
     maybe(
         conda_create_rule,
         name,

--- a/docs/docs/usage/api.md
+++ b/docs/docs/usage/api.md
@@ -27,8 +27,8 @@
 
     | Name          | Description                                                                                                      | Default                |
     | ------------- | ---------------------------------------------------------------------------------------------------------------- | ---------------------- |
+    | `name`        | Name of the environment                                                                                          |                        |
     | `environment` | label pointing to environment configuration file (typically named `environment.yml`)                             |                        |
-    | `name`        | Name of the environment                                                                                          | `my_env`               |
     | `quiet`       | `True` if `conda` output should be hidden                                                                        | `True`                 |
     | `timeout`     | How many seconds each execute action can take                                                                    | `3600`                 |
     | `clean`       | `True` if `conda` cache should be cleaned (less space taken, but slower subsequent builds)                       | `False`                |


### PR DESCRIPTION
It's unnecessary as you need to know about the name for anything to be usable